### PR TITLE
Bump assertj-core from 3.23.1 to 3.24.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,7 @@ dependencies {
 
 dependencies {
     testImplementation("com.navercorp.fixturemonkey:fixture-monkey:0.4.9")
-    testImplementation("org.assertj:assertj-core:3.23.1")
+    testImplementation("org.assertj:assertj-core:3.24.2")
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.1")
     testRuntimeOnly("ch.qos.logback:logback-classic:1.3.5")
     testRuntimeOnly("org.apache.logging.log4j:log4j-to-slf4j:2.19.0")


### PR DESCRIPTION
Bumps assertj-core from 3.23.1 to 3.24.2.

---
updated-dependencies:
- dependency-name: org.assertj:assertj-core dependency-type: direct:production update-type: version-update:semver-minor ...